### PR TITLE
Fix risk tab to include all 10 risks

### DIFF
--- a/0-1-risks/OSS1-Known-Vulnerabilities.md
+++ b/0-1-risks/OSS1-Known-Vulnerabilities.md
@@ -1,4 +1,4 @@
-## Known vulnerabilities in dependencies
+## OSS-RISK-1 : Known vulnerabilities in dependencies
 
 **Description:**
 

--- a/0-1-risks/OSS10-UnderOversized-Dependency.md
+++ b/0-1-risks/OSS10-UnderOversized-Dependency.md
@@ -1,4 +1,4 @@
-## Under/over-sized Dependency
+## OSS-RISK-10 : Under/over-sized Dependency
 
 **Description:**
 

--- a/0-1-risks/OSS2-Compromise-Legitimate-Package.md
+++ b/0-1-risks/OSS2-Compromise-Legitimate-Package.md
@@ -1,4 +1,4 @@
-## Compromise of Legitimate Package
+## OSS-RISK-2 : Compromise of Legitimate Package
 
 **Description:**
 

--- a/0-1-risks/OSS3-Name-Confusion-Attack.md
+++ b/0-1-risks/OSS3-Name-Confusion-Attack.md
@@ -1,4 +1,4 @@
-## Name Confusion Attacks
+## OSS-RISK-3 : Name Confusion Attacks
 
 **Description:**
 

--- a/0-1-risks/OSS4-Unmaintained-Software.md
+++ b/0-1-risks/OSS4-Unmaintained-Software.md
@@ -1,4 +1,4 @@
-## Unmaintained software
+## OSS-RISK-4 : Unmaintained software
 
 **Description:**
 

--- a/0-1-risks/OSS5-Outdated-Software.md
+++ b/0-1-risks/OSS5-Outdated-Software.md
@@ -1,4 +1,4 @@
-## Outdated software
+## OSS-RISK-5 : Outdated software
 
 **Description:**
 

--- a/0-1-risks/OSS6-Untracked-Dependencies.md
+++ b/0-1-risks/OSS6-Untracked-Dependencies.md
@@ -1,4 +1,4 @@
-## Untracked Dependencies
+## OSS-RISK-6 : Untracked Dependencies
 
 **Description:**
 

--- a/0-1-risks/OSS7-License-Regulatory-Risks.md
+++ b/0-1-risks/OSS7-License-Regulatory-Risks.md
@@ -1,4 +1,4 @@
-## License and Regulatory Risk
+## OSS-RISK-7 : License and Regulatory Risk
 
 **Description:**
 

--- a/0-1-risks/OSS8-Immature-Software.md
+++ b/0-1-risks/OSS8-Immature-Software.md
@@ -1,4 +1,4 @@
-## Immature-Software
+## OSS-RISK-8 : Immature-Software
 
 **Description:**
 

--- a/0-1-risks/OSS9-Unapproved-Change.md
+++ b/0-1-risks/OSS9-Unapproved-Change.md
@@ -1,4 +1,4 @@
-## Unapproved Change (Mutable)
+## OSS-RISK-9 : Unapproved Change (Mutable)
 
 **Description:**
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 group :jekyll_plugins do
     gem "github-pages"
 end
+gem "webrick", "~> 1.7"

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 remote_theme: "owasp/www--site-theme@main"
+permalink: :path
 plugins:
  - jekyll-include-cache-0.2.0

--- a/index.md
+++ b/index.md
@@ -1,9 +1,10 @@
 ---
-
-title: OWASP Top 10 Risks for Open Source Software
 layout: col-sidebar
+title: OWASP Top 10 Risks for Open Source Software
 level: 2
-
+type: documentation
+tags: top-10, open source, security, operations
+pitch: Top-10 security and operational risks related to using OSS. 
 ---
 
 ![top 10 oss risks](/assets/images/top10.png)

--- a/tab_risks.md
+++ b/tab_risks.md
@@ -1,25 +1,45 @@
 ---
-title: Risk Descriptions
+title: Risks
+layout:  null
 tab: true
 order: 1
+tags: top-10, open source, security, operations
 ---
 
 {% include_relative 0-1-risks/OSS1-Known-Vulnerabilities.md %}
 
+---
+
 {% include_relative 0-1-risks/OSS2-Compromise-Legitimate-Package.md %}
+
+---
 
 {% include_relative 0-1-risks/OSS3-Name-Confusion-Attack.md %}
 
+---
+
 {% include_relative 0-1-risks/OSS4-Unmaintained-Software.md %}
+
+---
 
 {% include_relative 0-1-risks/OSS5-Outdated-Software.md %}
 
+---
+
 {% include_relative 0-1-risks/OSS6-Untracked-Dependencies.md %}
+
+---
 
 {% include_relative 0-1-risks/OSS7-License-Regulatory-Risks.md %}
 
+---
+
 {% include_relative 0-1-risks/OSS8-Immature-Software.md %}
 
+---
+
 {% include_relative 0-1-risks/OSS9-Unapproved-Change.md %}
+
+---
 
 {% include_relative 0-1-risks/OSS10-UnderOversized-Dependency.md %}


### PR DESCRIPTION
- Fixed the risks tab to include the individual risk files from directory `0-1-risks` using the `include-relative` directive